### PR TITLE
Remove Silverstripe CMS module requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
     "issues": "https://github.com/mediabeastnz/silverstripe-flat-admin/issues"
   },
   "require": {
-    "silverstripe/framework": "~3.2",
-    "silverstripe/cms": "~3.2"
+    "silverstripe/framework": "~3.2"
   },
   "extra": {
     "screenshots": [


### PR DESCRIPTION
It is not necessary for this module to work.
